### PR TITLE
Fix NilClass exception when assigning a taggable attribute to empty string

### DIFF
--- a/lib/rocket_tag/taggable.rb
+++ b/lib/rocket_tag/taggable.rb
@@ -23,7 +23,7 @@ module RocketTag
           # but must be
           #
           #     hello,"foo"
-
+          return [] if list.empty?
           list = list.gsub /,\s+"/, ',"'
           list = list.parse_csv.map &:strip
         else

--- a/spec/rocket_tag/taggable_spec.rb
+++ b/spec/rocket_tag/taggable_spec.rb
@@ -14,6 +14,11 @@ describe TaggableModel do
       m = TaggableModel.new :skills => %q%hello, "is it me, you are looking for", cat%
       m.skills.should == ["hello", "is it me, you are looking for", "cat"]
     end
+
+    it "parses an empty string to an empty array" do
+      m = TaggableModel.new :skills => ""
+      m.skills.should == []
+    end
   end
 
   describe "#save" do


### PR DESCRIPTION
When you assign empty string to a taggable attribute, parse_csv returns nil instead of an empty array.  This causes the parse_tags method to fail with a NilClass exception.

I've added a spec that fails without the patch and passes with the patch to verify this behavior.
