### PR TITLE
Postgres fix

### DIFF
--- a/lib/rocket_tag/taggable.rb
+++ b/lib/rocket_tag/taggable.rb
@@ -158,7 +158,7 @@ module RocketTag
             joins{tags}.
             where{tags.name.in(my{tags_list})}.
             _with_tag_context(on).
-            group(self.column_names)
+            group(self.column_names.map{|col| "#{self.table_name}.#{col}"})
 
         # Wrap the inner query with an outer query to shield
         # the group and aggregate clauses from downstream

--- a/lib/rocket_tag/taggable.rb
+++ b/lib/rocket_tag/taggable.rb
@@ -159,7 +159,7 @@ module RocketTag
             joins{tags}.
             where{tags.name.in(my{tags_list})}.
             _with_tag_context(on).
-            group{~id}
+            group(self.column_names)
 
         # Wrap the inner query with an outer query to shield
         # the group and aggregate clauses from downstream

--- a/lib/rocket_tag/taggable.rb
+++ b/lib/rocket_tag/taggable.rb
@@ -44,8 +44,7 @@ module RocketTag
     end
 
     def taggings_for_context context
-      #taggings.where{taggings.context==my{context}}
-      taggings.where("context=?",context)
+      taggings.where{taggings.context==my{context}}
     end
 
     def destroy_tags_for_context context

--- a/lib/rocket_tag/taggable.rb
+++ b/lib/rocket_tag/taggable.rb
@@ -44,7 +44,8 @@ module RocketTag
     end
 
     def taggings_for_context context
-      taggings.where{taggings.context==my{context}}
+      #taggings.where{taggings.context==my{context}}
+      taggings.where("context=?",context)
     end
 
     def destroy_tags_for_context context


### PR DESCRIPTION
I ran into this issue when deploying to Heroku, which runs postgresql.  

ActionView::Template::Error (PG::Error: ERROR:  column "operators.name" must appear in the GROUP BY clause or be used in an aggregate function
2012-06-08T10:28:28+00:00 app[web.1]: : SELECT \* FROM (SELECT count("operators"."id") AS tags_count, operators.\* FROM "operators" INNER JOIN "taggings" ON "taggings"."taggable_id" = "operators"."id" AND "taggings"."taggable_type" = 'Operator' INNER JOIN "tags" ON "tags"."id" = "taggings"."tag_id" WHERE "tags"."name" IN ('music') GROUP BY "operators"."id") operators ):

The requirements for group by in aggregate SQL are different than MySQL.  All column names must be listed in the group by statement.  There is good discussion about it here:

http://stackoverflow.com/questions/1769361/postgresql-group-by-different-from-mysql

Listing the model's column_names in the group by fixes the issue for postgres.
