### PR TITLE
Fix for issue #21, postgresql group by issue

### DIFF
--- a/lib/rocket_tag/taggable.rb
+++ b/lib/rocket_tag/taggable.rb
@@ -10,8 +10,9 @@ module Squeel
         #
         # This little helper generates such a group by
         def group_by_all_columns
-          cn = self.column_names
-          group { cn.map { |col| __send__(col) } }
+          model_columns = self.column_names
+          tag_columns = %w(taggings.id tags.id)
+          group { model_columns.map { |col| __send__(col) } + tag_columns }
         end
 
       end


### PR DESCRIPTION
this allows the tagged_with and tags ClassMethods to function properly on postgresql, tested on 9.1.3

https://github.com/bradphelan/rocket_tag/issues/21
  added a simple fix to group_by_all_columns to include the columns 'taggings.id' and 'tags.id'
