### PR TITLE
Fixed a bug on taggings_for_context

### DIFF
--- a/lib/rocket_tag/taggable.rb
+++ b/lib/rocket_tag/taggable.rb
@@ -61,8 +61,8 @@ module RocketTag
       end
     end
 
-    def taggings_for_context context
-      taggings.where{taggings.context==context.to_s}
+    def taggings_for_context context_val
+      taggings.where{ taggings.context == context_val.to_s }
     end
 
     def destroy_tags_for_context context


### PR DESCRIPTION
Hi,

I just downloaded your gem and found out there's a bug on taggable model save. It throws:

`
ActiveRecord::StatementInvalid: Mysql2::Error: 
Unknown column 'taggings.skills' in 'where clause': 
DELETE FROM 'taggings' WHERE 'taggings'.'taggable_id' = 192 AND 'taggings'.'taggable_type' = 'User' AND 'taggings'.'context' = 'taggings'.'skills'
`

I fixed it by using a different var name `context_val` instead of `context` which references the `context` column in `taggings_for_context` method.

Btw, your gem is very good and simple to use. :)
