### PR TITLE
Allow passing a string instead of an array to TaggableModel.tagged_with

### DIFF
--- a/lib/rocket_tag/taggable.rb
+++ b/lib/rocket_tag/taggable.rb
@@ -197,7 +197,7 @@ module RocketTag
 
           c = tags_list.each_key.map do |context|
             squeel do
-              list = tags_list[context]
+              list = Array.wrap(tags_list[context])
               clean_list = RocketTag.clean_tags(list)
               clean_list << alias_tag_names.call(clean_list)
               clean_list.flatten!
@@ -210,6 +210,8 @@ module RocketTag
           q = q.where(c)
 
         else
+          tags_list = Array(tags_list)
+
           # Any tag can match any context
           clean_list = RocketTag.clean_tags(tags_list)
           clean_list << alias_tag_names.call(clean_list)

--- a/spec/rocket_tag/taggable_spec.rb
+++ b/spec/rocket_tag/taggable_spec.rb
@@ -207,6 +207,20 @@ describe TaggableModel do
     end
 
     describe "#tagged_with" do
+      describe 'passed argument' do
+        subject { TaggableModel.create(:skills => ['foo']) }
+
+        it 'should be possible to pass an array as the argument' do
+          TaggableModel.tagged_with(['foo'], :on => :skills).should eq([subject])
+          TaggableModel.tagged_with(:skills => ['foo']).should eq([subject])
+        end
+
+        it 'should be possible to pass a string as the argument' do
+          TaggableModel.tagged_with('foo', :on => :skills).should eq([subject])
+          TaggableModel.tagged_with(:skills => 'foo').should eq([subject])
+        end
+      end
+
       it "should count the number of matched tags" do
         r = TaggableModel.tagged_with(["a", "b", "german"]).all
         r.find{|i|i.name == "00"}.tags_count.should == 3


### PR DESCRIPTION
Updated from #43, should be mergable now.
