### PR TITLE
undefined method `strip' for nil:NilClass

### DIFF
--- a/lib/rocket_tag/taggable.rb
+++ b/lib/rocket_tag/taggable.rb
@@ -43,6 +43,7 @@ module RocketTag
           #     hello,"foo"
           return [] if list.empty?
           list = list.gsub /,\s+"/, ',"'
+          list = list.gsub /\n/,    ''
           list = list.parse_csv.map &:strip
         else
           list

--- a/spec/rocket_tag/taggable_spec.rb
+++ b/spec/rocket_tag/taggable_spec.rb
@@ -13,6 +13,9 @@ describe TaggableModel do
 
       m = TaggableModel.new :skills => %q%hello, "is it me, you are looking for", cat%
       m.skills.should == ["hello", "is it me, you are looking for", "cat"]
+
+      m = TaggableModel.new :skills => "hello,\n is it me\n you are looking for,\n cat"
+      m.skills.should == ["hello", "is it me you are looking for", "cat"]
     end
 
     it "parses an empty string to an empty array" do


### PR DESCRIPTION
I tried to create a post, although it returned an `undefined method 'strip' for nil:NilClass`. Searching for the root of the problem I figured out that `#parse_csv` can mistakely create Nil entries in array.

Take this as example:

```
"some text,\nandsomemore,,".parse_csv
=> ["some text", nil]
```
